### PR TITLE
Rename Workflows to Experts

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -15,8 +15,8 @@
               <li class="nav-item" :class="{ active: $route.name === 'Assistants' }">
                 <router-link to="/">Assistants</router-link>
               </li>
-              <li class="nav-item" :class="{ active: $route.name === 'Workflows' }">
-                <router-link to="/workflows">Workflows</router-link>
+              <li class="nav-item" :class="{ active: $route.name === 'Experts' }">
+                <router-link to="/experts">Experts</router-link>
               </li>
               <li class="nav-item" :class="{ active: $route.name === 'Tools' }">
                 <router-link to="/tools">Tools</router-link>

--- a/src/router.js
+++ b/src/router.js
@@ -2,7 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router';
 import Assistants from './views/Assistants.vue';
 import Tools from './views/Tools.vue';
 import Assistant from './views/Assistant.vue';
-import Workflows from './views/Workflows.vue';
+import Experts from './views/Experts.vue';
 
 const routes = [
   {
@@ -22,9 +22,9 @@ const routes = [
     props: true,
   },
   {
-    path: '/workflows',
-    name: 'Workflows',
-    component: Workflows,
+    path: '/experts',
+    name: 'Experts',
+    component: Experts,
   },
 ];
 

--- a/src/views/Experts.vue
+++ b/src/views/Experts.vue
@@ -1,0 +1,6 @@
+<template>
+  <div>
+    <h2>Experts</h2>
+    <p>Experts view placeholder.</p>
+  </div>
+</template> 

--- a/src/views/Workflows.vue
+++ b/src/views/Workflows.vue
@@ -1,6 +1,0 @@
-<template>
-  <div>
-    <h2>Workflows</h2>
-    <p>Workflows view placeholder.</p>
-  </div>
-</template> 


### PR DESCRIPTION
## Summary
- rename `Workflows` view file to `Experts`
- update router to reference the new Experts view and URL path
- update navigation links to Experts

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68545e3319d88325906ea9a9f7f1caf2