### PR TITLE
Enable conversation detail navigation

### DIFF
--- a/src/components/ActivityListItem.vue
+++ b/src/components/ActivityListItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="activity-list-item">
+  <RouterLink :to="to" class="activity-list-item">
     <div class="activity-datetime">{{ formatDate(item.datetime) }}</div>
     <div class="activity-event">{{ item.event }}</div>
     <div class="activity-summary">{{ item.summary }}</div>
@@ -7,16 +7,21 @@
       <img :src="gravatarUrl(item.customer)" alt="Gravatar" width="28" height="28" class="activity-gravatar" :title="item.customer" />
       <!-- {{ item.customer }} -->
     </div>
-  </div>
+  </RouterLink>
 </template>
 
 <script setup>
 import CryptoJS from 'crypto-js';
+import { RouterLink } from 'vue-router';
 
 const props = defineProps({
   item: {
     type: Object,
     required: true
+  },
+  to: {
+    type: String,
+    required: true,
   }
 });
 

--- a/src/data/assistants.js
+++ b/src/data/assistants.js
@@ -24,22 +24,28 @@ export const assistants = [
     `,
     activity: [
       {
+        id: 1,
         datetime: '2024-06-10T14:12:00Z',
         event: 'New reply (existing chat)',
         customer: 'koalababy3@gmail.com',
         summary: 'Reviewed support history and provided a fix for a recurring login issue.',
+        conversationId: 1,
       },
       {
+        id: 2,
         datetime: '2024-06-10T13:45:00Z',
         event: 'First reply',
         customer: 'shaun@shaunandrews.com',
-        summary: 'Customer had a question about upgrading their WordPress.com plan. Provided relevant support article and offered further assistance.'
+        summary: 'Customer had a question about upgrading their WordPress.com plan. Provided relevant support article and offered further assistance.',
+        conversationId: 2,
       },
       {
+        id: 3,
         datetime: '2024-06-09T17:30:00Z',
         event: 'Escalation',
         customer: 'cain@automattic.com',
-        summary: 'Escalated a billing issue to a human agent after insufficient information was found in the reference tool.'
+        summary: 'Escalated a billing issue to a human agent after insufficient information was found in the reference tool.',
+        conversationId: 3,
       }
     ],
     trigger: 'chat-message',
@@ -95,19 +101,25 @@ export const assistants = [
     `,
     activity: [
       {
+        id: 4,
         datetime: '2024-06-10T09:00:00Z',
         event: 'New email received',
-        summary: 'Triaged a user email about password reset. Sent automated response with instructions and flagged for follow-up.'
+        summary: 'Triaged a user email about password reset. Sent automated response with instructions and flagged for follow-up.',
+        conversationId: 4,
       },
       {
+        id: 5,
         datetime: '2024-06-09T16:20:00Z',
         event: 'Reference lookup',
-        summary: 'Provided a support article link for a user asking about Tumblr blog customization.'
+        summary: 'Provided a support article link for a user asking about Tumblr blog customization.',
+        conversationId: 5,
       },
       {
+        id: 6,
         datetime: '2024-06-08T11:05:00Z',
         event: 'Escalation',
-        summary: 'Escalated a technical issue to a human agent after automated troubleshooting failed.'
+        summary: 'Escalated a technical issue to a human agent after automated troubleshooting failed.',
+        conversationId: 6,
       }
     ],
     trigger: 'email-message',
@@ -133,19 +145,25 @@ export const assistants = [
     `,
     activity: [
       {
+        id: 7,
         datetime: '2024-06-10T08:30:00Z',
         event: 'Scheduled check',
-        summary: 'Identified 2 overdue projects in Linear. Sent Slack reminders to project owners.'
+        summary: 'Identified 2 overdue projects in Linear. Sent Slack reminders to project owners.',
+        conversationId: 7,
       },
       {
+        id: 8,
         datetime: '2024-06-09T08:30:00Z',
         event: 'Scheduled check',
-        summary: 'No overdue projects found during daily check.'
+        summary: 'No overdue projects found during daily check.',
+        conversationId: 8,
       },
       {
+        id: 9,
         datetime: '2024-06-08T08:30:00Z',
         event: 'Slack notification',
-        summary: 'Sent a reminder to the last updater of an overdue project after no owner was listed.'
+        summary: 'Sent a reminder to the last updater of an overdue project after no owner was listed.',
+        conversationId: 9,
       }
     ],
     trigger: 'scheduled',
@@ -195,19 +213,25 @@ export const assistants = [
     `,
     activity: [
       {
+        id: 10,
         datetime: '2024-06-10T15:00:00Z',
         event: 'On-demand',
-        summary: 'Returned the HTML for a requested "cover" block from a user-provided snippet.'
+        summary: 'Returned the HTML for a requested "cover" block from a user-provided snippet.',
+        conversationId: 10,
       },
       {
+        id: 11,
         datetime: '2024-06-09T12:10:00Z',
         event: 'On-demand',
-        summary: 'Could not find the requested block. Provided a helpful error message and suggestions.'
+        summary: 'Could not find the requested block. Provided a helpful error message and suggestions.',
+        conversationId: 11,
       },
       {
+        id: 12,
         datetime: '2024-06-08T10:45:00Z',
         event: 'On-demand',
-        summary: 'Parsed malformed HTML and successfully returned the requested block.'
+        summary: 'Parsed malformed HTML and successfully returned the requested block.',
+        conversationId: 12,
       }
     ],
     trigger: 'on-demand',
@@ -234,19 +258,25 @@ export const assistants = [
     `,
     activity: [
       {
+        id: 13,
         datetime: '2024-06-11T10:00:00Z',
         event: 'Slack trigger',
-        summary: 'Detected a Slack message requesting a meeting. Checked availability for 4 participants.'
+        summary: 'Detected a Slack message requesting a meeting. Checked availability for 4 participants.',
+        conversationId: 13,
       },
       {
+        id: 14,
         datetime: '2024-06-11T10:01:00Z',
         event: 'Calendar lookup',
-        summary: 'Found a mutually available slot at 2:00pm. Created a calendar event and sent invites.'
+        summary: 'Found a mutually available slot at 2:00pm. Created a calendar event and sent invites.',
+        conversationId: 14,
       },
       {
+        id: 15,
         datetime: '2024-06-11T10:02:00Z',
         event: 'Slack notification',
-        summary: 'Sent a Slack message summarizing the scheduled meeting and participants.'
+        summary: 'Sent a Slack message summarizing the scheduled meeting and participants.',
+        conversationId: 15,
       }
     ],
     trigger: 'slack-message',
@@ -271,19 +301,25 @@ export const assistants = [
     `,
     activity: [
       {
+        id: 16,
         datetime: '2024-06-12T09:00:00Z',
         event: 'Slack message',
-        summary: 'Helped a user find the DRI for a new project by searching P2 sites.'
+        summary: 'Helped a user find the DRI for a new project by searching P2 sites.',
+        conversationId: 16,
       },
       {
+        id: 17,
         datetime: '2024-06-11T16:30:00Z',
         event: 'Insight search',
-        summary: 'Provided a summary of recent discussions about a product launch from multiple P2s.'
+        summary: 'Provided a summary of recent discussions about a product launch from multiple P2s.',
+        conversationId: 17,
       },
       {
+        id: 18,
         datetime: '2024-06-10T14:45:00Z',
         event: 'Resource location',
-        summary: 'Directed a user to the correct P2 for onboarding documentation.'
+        summary: 'Directed a user to the correct P2 for onboarding documentation.',
+        conversationId: 18,
       }
     ],
     trigger: 'slack-message',

--- a/src/data/conversations.js
+++ b/src/data/conversations.js
@@ -1,0 +1,144 @@
+export const conversations = [
+  {
+    id: 1,
+    assistantId: 1,
+    messages: [
+      { role: 'user', text: "I'm still having trouble logging in." },
+      { role: 'assistant', text: 'I checked your support history and it looks like clearing your cookies often helps. Can you try that and reset your password again?' }
+    ]
+  },
+  {
+    id: 2,
+    assistantId: 1,
+    messages: [
+      { role: 'user', text: 'How do I upgrade my plan?' },
+      { role: 'assistant', text: 'Sure! You can upgrade your plan from your billing settings. Here is a link with more details: https://wordpress.com/support/plans/' }
+    ]
+  },
+  {
+    id: 3,
+    assistantId: 1,
+    messages: [
+      { role: 'user', text: 'I have a billing issue that I need help with.' },
+      { role: 'assistant', text: 'I am not able to resolve this. I will escalate this to a human agent for further assistance.' }
+    ]
+  },
+  {
+    id: 4,
+    assistantId: 2,
+    messages: [
+      { role: 'user', text: 'Please help me reset my Tumblr password.' },
+      { role: 'assistant', text: 'No problem! I have sent you an email with password reset instructions.' }
+    ]
+  },
+  {
+    id: 5,
+    assistantId: 2,
+    messages: [
+      { role: 'user', text: 'How do I customize my blog theme?' },
+      { role: 'assistant', text: 'Here is a guide that should help: https://help.tumblr.com/hc/en-us/articles/360041542954-Customizing-your-blog' }
+    ]
+  },
+  {
+    id: 6,
+    assistantId: 2,
+    messages: [
+      { role: 'user', text: 'Something went wrong with my account.' },
+      { role: 'assistant', text: 'This looks complicated. I am escalating to a human agent.' }
+    ]
+  },
+  {
+    id: 7,
+    assistantId: 3,
+    messages: [
+      { role: 'system', text: 'Daily check detected overdue projects.' },
+      { role: 'assistant', text: 'Sent reminders in Slack to project owners.' }
+    ]
+  },
+  {
+    id: 8,
+    assistantId: 3,
+    messages: [
+      { role: 'system', text: 'Daily check completed.' },
+      { role: 'assistant', text: 'No overdue projects found.' }
+    ]
+  },
+  {
+    id: 9,
+    assistantId: 3,
+    messages: [
+      { role: 'assistant', text: 'Sent reminder to last updater because no owner was set.' }
+    ]
+  },
+  {
+    id: 10,
+    assistantId: 4,
+    messages: [
+      { role: 'user', text: 'Can you find the cover block in this HTML snippet?' },
+      { role: 'assistant', text: '<div class="wp-block-cover">...</div>' }
+    ]
+  },
+  {
+    id: 11,
+    assistantId: 4,
+    messages: [
+      { role: 'user', text: 'Find the gallery block.' },
+      { role: 'assistant', text: 'I could not find a gallery block. Did you mean a different block?' }
+    ]
+  },
+  {
+    id: 12,
+    assistantId: 4,
+    messages: [
+      { role: 'user', text: 'Here is some messy HTML, find the heading.' },
+      { role: 'assistant', text: '<h2>Example Heading</h2>' }
+    ]
+  },
+  {
+    id: 13,
+    assistantId: 5,
+    messages: [
+      { role: 'user', text: 'Can we schedule a meeting with everyone tomorrow?' },
+      { role: 'assistant', text: 'I found a time at 2:00pm that works for everyone. Sending invites now.' }
+    ]
+  },
+  {
+    id: 14,
+    assistantId: 5,
+    messages: [
+      { role: 'system', text: 'Checked calendars.' },
+      { role: 'assistant', text: 'Created event and invited participants.' }
+    ]
+  },
+  {
+    id: 15,
+    assistantId: 5,
+    messages: [
+      { role: 'assistant', text: 'Sent Slack message with meeting details.' }
+    ]
+  },
+  {
+    id: 16,
+    assistantId: 6,
+    messages: [
+      { role: 'user', text: 'Who is the DRI for the new project?' },
+      { role: 'assistant', text: 'The DRI is Jane Doe. Here is a P2 link with more info.' }
+    ]
+  },
+  {
+    id: 17,
+    assistantId: 6,
+    messages: [
+      { role: 'user', text: 'What are people saying about the product launch?' },
+      { role: 'assistant', text: 'Here is a summary of the latest discussions on P2.' }
+    ]
+  },
+  {
+    id: 18,
+    assistantId: 6,
+    messages: [
+      { role: 'user', text: 'Where can I find onboarding docs?' },
+      { role: 'assistant', text: 'Check out this P2 post with the onboarding steps.' }
+    ]
+  }
+];

--- a/src/router.js
+++ b/src/router.js
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from 'vue-router';
 import Assistants from './views/Assistants.vue';
 import Tools from './views/Tools.vue';
 import Assistant from './views/Assistant.vue';
+import Conversation from './views/Conversation.vue';
 import Experts from './views/Experts.vue';
 
 const routes = [
@@ -19,6 +20,12 @@ const routes = [
     path: '/assistant/:id',
     name: 'Assistant',
     component: Assistant,
+    props: true,
+  },
+  {
+    path: '/assistant/:id/activity/:activityId',
+    name: 'Conversation',
+    component: Conversation,
     props: true,
   },
   {

--- a/src/views/Assistant.vue
+++ b/src/views/Assistant.vue
@@ -84,7 +84,12 @@
     </div>
 
     <div v-if="assistant && activeTab === 'activity'" class="assistant-activity vstack">
-        <ActivityListItem v-for="(item, idx) in assistant.activity" :key="idx" :item="item" />
+        <ActivityListItem
+          v-for="(item, idx) in assistant.activity"
+          :key="idx"
+          :item="item"
+          :to="`/assistant/${assistant.id}/activity/${item.id}`"
+        />
     </div>
 
     <Modal :isOpen="isToolModalOpen" @close="closeToolModal">

--- a/src/views/Conversation.vue
+++ b/src/views/Conversation.vue
@@ -1,0 +1,87 @@
+<template>
+  <div class="conversation-view">
+    <header>
+      <router-link :to="backLink" class="back-link">Back to Activity</router-link>
+      <h2>Conversation Detail</h2>
+    </header>
+    <div v-if="conversation">
+      <div class="conversation-meta">
+        <div class="meta-row"><strong>Date:</strong> {{ formatDate(conversationItem.datetime) }}</div>
+        <div class="meta-row"><strong>Event:</strong> {{ conversationItem.event }}</div>
+        <div class="meta-row" v-if="conversationItem.customer"><strong>Customer:</strong> {{ conversationItem.customer }}</div>
+      </div>
+      <div class="messages">
+        <div v-for="(msg, idx) in conversation.messages" :key="idx" :class="['message', msg.role]">
+          <span class="role">{{ msg.role }}:</span>
+          <span class="text">{{ msg.text }}</span>
+        </div>
+      </div>
+    </div>
+    <div v-else>
+      <p>Conversation not found.</p>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { useRoute } from 'vue-router';
+import { assistants } from '@/data/assistants.js';
+import { conversations } from '@/data/conversations.js';
+
+const route = useRoute();
+const assistantId = computed(() => Number(route.params.id));
+const activityId = computed(() => Number(route.params.activityId));
+
+const assistant = computed(() => assistants.find(a => a.id === assistantId.value));
+const conversationItem = computed(() => assistant.value?.activity.find(a => a.id === activityId.value));
+const conversation = computed(() => {
+  const convId = conversationItem.value?.conversationId;
+  return conversations.find(c => c.id === convId);
+});
+
+const backLink = computed(() => `/assistant/${assistantId.value}?tab=activity`);
+
+function formatDate(datetime) {
+  const date = new Date(datetime);
+  return date.toLocaleString();
+}
+</script>
+
+<style scoped>
+.conversation-view {
+  padding: var(--space-m);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-m);
+}
+header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-m);
+}
+.back-link {
+  text-decoration: none;
+  color: var(--color-accent-fg);
+}
+.messages {
+  border-top: 1px solid var(--color-surface-tint);
+  padding-top: var(--space-m);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-s);
+}
+.message {
+  padding: var(--space-xs) var(--space-s);
+  background-color: var(--color-surface-tint);
+  border-radius: var(--radius);
+}
+.message.assistant {
+  background-color: var(--color-accent);
+  color: var(--color-accent-fg);
+}
+.role {
+  font-weight: bold;
+  margin-right: var(--space-xs);
+}
+</style>


### PR DESCRIPTION
## Summary
- make Activity list items links
- add conversation dataset
- show conversation messages in a new Conversation view
- connect new Conversation route

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685470bfcb0c8325882228cbc7bd2287