### PR TITLE
Rename Assistant to Agent

### DIFF
--- a/.cursor/rules/assistants-data.mdc
+++ b/.cursor/rules/assistants-data.mdc
@@ -3,10 +3,10 @@ description:
 globs:
 alwaysApply: false
 ---
-# Assistant Data Source
+# Agent Data Source
 
-The list of assistants displayed in the app is powered by a static, mocked data array found in [src/data/assistants.js](mdc:src/data/assistants.js).
+The list of agents displayed in the app is powered by a static, mocked data array found in [src/data/agents.js](mdc:src/data/agents.js).
 
-- To add, remove, or update assistants, edit this file directly.
-- Each assistant object includes: `id`, `title`, `description`, and a `tools` array (with `icon`, `title`, and optional `subtitle`).
-- This data is used in [src/views/Assistants.vue](mdc:src/views/Assistants.vue) to render the assistant list.
+- To add, remove, or update agents, edit this file directly.
+- Each agent object includes: `id`, `title`, `description`, and a `tools` array (with `icon`, `title`, and optional `subtitle`).
+- This data is used in [src/views/Agents.vue](mdc:src/views/Agents.vue) to render the agent list.

--- a/src/App.vue
+++ b/src/App.vue
@@ -8,8 +8,8 @@
         </h1>
         <nav>
           <ul>
-              <li class="nav-item" :class="{ active: $route.name === 'Assistants' || $route.name === 'Assistant' || $route.path.startsWith('/assistant') }">
-                <router-link to="/">Assistants</router-link>
+              <li class="nav-item" :class="{ active: $route.name === 'Agents' || $route.name === 'Agent' || $route.path.startsWith('/agent') }">
+                <router-link to="/">Agents</router-link>
               </li>
               <li class="nav-item" :class="{ active: $route.name === 'Experts' }">
                 <router-link to="/experts">Experts</router-link>

--- a/src/components/AgentPreview.vue
+++ b/src/components/AgentPreview.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="assistant-preview">
+  <div class="agent-preview">
     <div class="section-header">
       <h4 class="section-title">Preview</h4>
-      <p class="section-description">See how this assistant behaves and chat with it.</p>
+      <p class="section-description">See how this agent behaves and chat with it.</p>
     </div>
     <div class="preview-start" v-if="!started">
       <button @click="startPreview"><Play :size="18" />Start preview <span class="shortcut"><Command :size="12" /> <CornerDownLeft :size="12" /></span></button>
@@ -44,7 +44,7 @@ import { ref, watch, nextTick } from 'vue';
 import { Play, Command, CornerDownLeft, Send, Check } from 'lucide-vue-next';
 
 const props = defineProps({
-  assistant: {
+  agent: {
     type: Object,
     required: true,
   },
@@ -58,7 +58,7 @@ const chatHistory = ref([]); // For user messages
 const waitingForInput = ref(false);
 
 function startPreview() {
-  if (!Array.isArray(props.assistant?.previewEvents) || props.assistant.previewEvents.length === 0) return;
+  if (!Array.isArray(props.agent?.previewEvents) || props.agent.previewEvents.length === 0) return;
   started.value = true;
   currentStep.value = 0;
   revealedEvents.value = [];
@@ -69,8 +69,8 @@ function startPreview() {
 }
 
 function runStep() {
-  if (currentStep.value >= props.assistant.previewEvents.length) return;
-  const event = props.assistant.previewEvents[currentStep.value];
+  if (currentStep.value >= props.agent.previewEvents.length) return;
+  const event = props.agent.previewEvents[currentStep.value];
   if (event.question) {
     revealedEvents.value.push({ ...event, state: 'question' });
     waitingForInput.value = true;
@@ -108,9 +108,9 @@ function onInputKeydown(e) {
   }
 }
 
-// Reset preview if assistant changes
+// Reset preview if agent changes
 watch(
-  () => props.assistant,
+  () => props.agent,
   () => {
     started.value = false;
     currentStep.value = -1;
@@ -123,7 +123,7 @@ watch(
 </script>
 
 <style scoped>
-.assistant-preview {
+.agent-preview {
   width: 40%;
   border-left: 1px solid var(--color-surface-tint);
   padding: var(--space-m);

--- a/src/data/agents.js
+++ b/src/data/agents.js
@@ -1,6 +1,6 @@
 import { tools } from './tools.js';
 
-export const assistants = [
+export const agents = [
   {
     id: 1,
     title: 'WP.com Support Chat',
@@ -15,7 +15,7 @@ export const assistants = [
       { ...tools.find(t => t.title === 'Reference'), subtitle: 'support.wordpress.com' }
     ],
     instructions: `
-        You are a helpful support assistant for WordPress.com. Use [tool title="Persona" value="Wappuu"] for all responses.
+        You are a helpful support agent for WordPress.com. Use [tool title="Persona" value="Wappuu"] for all responses.
         Review the [tool title="User Profile"] and [tool title="Support History"] to learn about the user and their past support interactions. Prioritize recent interactions and use this context in response if needed.
         Review the [tool title="Chat"] to see the user's previous messages and use this context in your response.
         If the user is asking about a specific issue, use the [tool title="Reference" value="support.wordpress.com"] tool to find the most relevant support article.
@@ -93,7 +93,7 @@ export const assistants = [
       { ...tools.find(t => t.title === 'Reference'), subtitle: 'support.tumblr.com' }
     ],
     instructions: `
-    You are a helpful support assistant for Tumblr.com. Use [tool title="Persona" value="TumblrBot"] for all responses.
+    You are a helpful support agent for Tumblr.com. Use [tool title="Persona" value="TumblrBot"] for all responses.
     Review the [tool title="Email" value="help@tumblr.com"] to see the user's email and use this context in your response.
     If the user is asking about a specific issue, use the [tool title="Reference" value="support.tumblr.com"] tool to find the most relevant support article.
     If you don't have the information to answer the user's question, say you don't know and escalate to a human agent.

--- a/src/data/conversations.js
+++ b/src/data/conversations.js
@@ -1,144 +1,144 @@
 export const conversations = [
   {
     id: 1,
-    assistantId: 1,
+    agentId: 1,
     messages: [
       { role: 'user', text: "I'm still having trouble logging in." },
-      { role: 'assistant', text: 'I checked your support history and it looks like clearing your cookies often helps. Can you try that and reset your password again?' }
+      { role: 'agent', text: 'I checked your support history and it looks like clearing your cookies often helps. Can you try that and reset your password again?' }
     ]
   },
   {
     id: 2,
-    assistantId: 1,
+    agentId: 1,
     messages: [
       { role: 'user', text: 'How do I upgrade my plan?' },
-      { role: 'assistant', text: 'Sure! You can upgrade your plan from your billing settings. Here is a link with more details: https://wordpress.com/support/plans/' }
+      { role: 'agent', text: 'Sure! You can upgrade your plan from your billing settings. Here is a link with more details: https://wordpress.com/support/plans/' }
     ]
   },
   {
     id: 3,
-    assistantId: 1,
+    agentId: 1,
     messages: [
       { role: 'user', text: 'I have a billing issue that I need help with.' },
-      { role: 'assistant', text: 'I am not able to resolve this. I will escalate this to a human agent for further assistance.' }
+      { role: 'agent', text: 'I am not able to resolve this. I will escalate this to a human agent for further assistance.' }
     ]
   },
   {
     id: 4,
-    assistantId: 2,
+    agentId: 2,
     messages: [
       { role: 'user', text: 'Please help me reset my Tumblr password.' },
-      { role: 'assistant', text: 'No problem! I have sent you an email with password reset instructions.' }
+      { role: 'agent', text: 'No problem! I have sent you an email with password reset instructions.' }
     ]
   },
   {
     id: 5,
-    assistantId: 2,
+    agentId: 2,
     messages: [
       { role: 'user', text: 'How do I customize my blog theme?' },
-      { role: 'assistant', text: 'Here is a guide that should help: https://help.tumblr.com/hc/en-us/articles/360041542954-Customizing-your-blog' }
+      { role: 'agent', text: 'Here is a guide that should help: https://help.tumblr.com/hc/en-us/articles/360041542954-Customizing-your-blog' }
     ]
   },
   {
     id: 6,
-    assistantId: 2,
+    agentId: 2,
     messages: [
       { role: 'user', text: 'Something went wrong with my account.' },
-      { role: 'assistant', text: 'This looks complicated. I am escalating to a human agent.' }
+      { role: 'agent', text: 'This looks complicated. I am escalating to a human agent.' }
     ]
   },
   {
     id: 7,
-    assistantId: 3,
+    agentId: 3,
     messages: [
       { role: 'system', text: 'Daily check detected overdue projects.' },
-      { role: 'assistant', text: 'Sent reminders in Slack to project owners.' }
+      { role: 'agent', text: 'Sent reminders in Slack to project owners.' }
     ]
   },
   {
     id: 8,
-    assistantId: 3,
+    agentId: 3,
     messages: [
       { role: 'system', text: 'Daily check completed.' },
-      { role: 'assistant', text: 'No overdue projects found.' }
+      { role: 'agent', text: 'No overdue projects found.' }
     ]
   },
   {
     id: 9,
-    assistantId: 3,
+    agentId: 3,
     messages: [
-      { role: 'assistant', text: 'Sent reminder to last updater because no owner was set.' }
+      { role: 'agent', text: 'Sent reminder to last updater because no owner was set.' }
     ]
   },
   {
     id: 10,
-    assistantId: 4,
+    agentId: 4,
     messages: [
       { role: 'user', text: 'Can you find the cover block in this HTML snippet?' },
-      { role: 'assistant', text: '<div class="wp-block-cover">...</div>' }
+      { role: 'agent', text: '<div class="wp-block-cover">...</div>' }
     ]
   },
   {
     id: 11,
-    assistantId: 4,
+    agentId: 4,
     messages: [
       { role: 'user', text: 'Find the gallery block.' },
-      { role: 'assistant', text: 'I could not find a gallery block. Did you mean a different block?' }
+      { role: 'agent', text: 'I could not find a gallery block. Did you mean a different block?' }
     ]
   },
   {
     id: 12,
-    assistantId: 4,
+    agentId: 4,
     messages: [
       { role: 'user', text: 'Here is some messy HTML, find the heading.' },
-      { role: 'assistant', text: '<h2>Example Heading</h2>' }
+      { role: 'agent', text: '<h2>Example Heading</h2>' }
     ]
   },
   {
     id: 13,
-    assistantId: 5,
+    agentId: 5,
     messages: [
       { role: 'user', text: 'Can we schedule a meeting with everyone tomorrow?' },
-      { role: 'assistant', text: 'I found a time at 2:00pm that works for everyone. Sending invites now.' }
+      { role: 'agent', text: 'I found a time at 2:00pm that works for everyone. Sending invites now.' }
     ]
   },
   {
     id: 14,
-    assistantId: 5,
+    agentId: 5,
     messages: [
       { role: 'system', text: 'Checked calendars.' },
-      { role: 'assistant', text: 'Created event and invited participants.' }
+      { role: 'agent', text: 'Created event and invited participants.' }
     ]
   },
   {
     id: 15,
-    assistantId: 5,
+    agentId: 5,
     messages: [
-      { role: 'assistant', text: 'Sent Slack message with meeting details.' }
+      { role: 'agent', text: 'Sent Slack message with meeting details.' }
     ]
   },
   {
     id: 16,
-    assistantId: 6,
+    agentId: 6,
     messages: [
       { role: 'user', text: 'Who is the DRI for the new project?' },
-      { role: 'assistant', text: 'The DRI is Jane Doe. Here is a P2 link with more info.' }
+      { role: 'agent', text: 'The DRI is Jane Doe. Here is a P2 link with more info.' }
     ]
   },
   {
     id: 17,
-    assistantId: 6,
+    agentId: 6,
     messages: [
       { role: 'user', text: 'What are people saying about the product launch?' },
-      { role: 'assistant', text: 'Here is a summary of the latest discussions on P2.' }
+      { role: 'agent', text: 'Here is a summary of the latest discussions on P2.' }
     ]
   },
   {
     id: 18,
-    assistantId: 6,
+    agentId: 6,
     messages: [
       { role: 'user', text: 'Where can I find onboarding docs?' },
-      { role: 'assistant', text: 'Check out this P2 post with the onboarding steps.' }
+      { role: 'agent', text: 'Check out this P2 post with the onboarding steps.' }
     ]
   }
 ];

--- a/src/data/parseInstructions.js
+++ b/src/data/parseInstructions.js
@@ -1,4 +1,4 @@
-// Simple parser for assistant instructions
+// Simple parser for agent instructions
 // Recognizes [tool title="..."] and [tool title="..." value="..."]
 
 export function parseInstructions(instructions) {

--- a/src/router.js
+++ b/src/router.js
@@ -1,15 +1,15 @@
 import { createRouter, createWebHistory } from 'vue-router';
-import Assistants from './views/Assistants.vue';
+import Agents from './views/Agents.vue';
 import Tools from './views/Tools.vue';
-import Assistant from './views/Assistant.vue';
+import Agent from './views/Agent.vue';
 import Conversation from './views/Conversation.vue';
 import Experts from './views/Experts.vue';
 
 const routes = [
   {
     path: '/',
-    name: 'Assistants',
-    component: Assistants,
+    name: 'Agents',
+    component: Agents,
   },
   {
     path: '/tools',
@@ -17,13 +17,13 @@ const routes = [
     component: Tools,
   },
   {
-    path: '/assistant/:id',
-    name: 'Assistant',
-    component: Assistant,
+    path: '/agent/:id',
+    name: 'Agent',
+    component: Agent,
     props: true,
   },
   {
-    path: '/assistant/:id/activity/:activityId',
+    path: '/agent/:id/activity/:activityId',
     name: 'Conversation',
     component: Conversation,
     props: true,

--- a/src/views/Agent.vue
+++ b/src/views/Agent.vue
@@ -1,8 +1,8 @@
 <template>
-  <div class="assistant-container">
-    <header v-if="assistant">
-      <div class="assistant-header-start">
-        <h2 class="assistant-title">{{ assistant.title }}</h2>
+  <div class="agent-container">
+    <header v-if="agent">
+      <div class="agent-header-start">
+        <h2 class="agent-title">{{ agent.title }}</h2>
         <nav>
           <ul>
             <li :class="{ active: activeTab === 'workbench' }" @click="activeTab = 'workbench'">Workbench</li>
@@ -12,21 +12,21 @@
           </ul>
         </nav>
       </div>
-      <div class="assistant-header-end">
+      <div class="agent-header-end">
         <button class="primary">Save</button>
       </div>
     </header>
 
-    <div v-else class="assistant-not-found">
-      <p>Assistant not found.</p>
+    <div v-else class="agent-not-found">
+      <p>Agent not found.</p>
     </div>
 
-    <div v-if="assistant && activeTab === 'workbench'" class="assistant-workbench hstack">
-      <div class="assistant-config vstack">
+    <div v-if="agent && activeTab === 'workbench'" class="agent-workbench hstack">
+      <div class="agent-config vstack">
         <div class="instructions">
           <div class="section-header">
             <h4 class="section-title">Instructions</h4>
-            <p class="section-description">Tell your assistant what to do. Add tools by typing @tool.</p>
+            <p class="section-description">Tell your agent what to do. Add tools by typing @tool.</p>
           </div>
           <InstructionsField
             :parsedInstructions="parsedInstructions"
@@ -43,11 +43,11 @@
         <div class="tools">
           <div class="section-header">
             <h4 class="section-title">Tools</h4>
-            <p class="section-description">Configure the tools available to your assistant.</p>
+            <p class="section-description">Configure the tools available to your agent.</p>
           </div>
           <div class="tools-list hstack">
             <ToolListItem
-              v-for="(tool, idx) in assistant.tools"
+              v-for="(tool, idx) in agent.tools"
               :key="idx"
               :icon="tool.icon"
               :title="tool.title"
@@ -59,12 +59,12 @@
         </div>
       </div>
 
-      <AssistantPreview :assistant="assistant" />
+      <AgentPreview :agent="agent" />
     </div>
 
-    <div v-if="assistant && activeTab === 'versions'" class="assistant-versions">
+    <div v-if="agent && activeTab === 'versions'" class="agent-versions">
       <h4>Description</h4>
-      <p>{{ assistant.description }}</p>
+      <p>{{ agent.description }}</p>
 
       <h4>Status</h4>
       <p>Active</p>
@@ -74,21 +74,21 @@
 
       <h4>Owner</h4>
       <div class="details-owner hstack">
-        <img :src="`/images/${assistant.ownerIcon}`" :alt="assistant.owner" width="24" height="24" class="owner-icon" />
-        <span class="owner-name">{{ assistant.owner }}</span>
+        <img :src="`/images/${agent.ownerIcon}`" :alt="agent.owner" width="24" height="24" class="owner-icon" />
+        <span class="owner-name">{{ agent.owner }}</span>
       </div>
     </div>
 
-    <div v-if="assistant && activeTab === 'insights'" class="assistant-insights">
+    <div v-if="agent && activeTab === 'insights'" class="agent-insights">
       <p>Insights coming soon.</p>
     </div>
 
-    <div v-if="assistant && activeTab === 'activity'" class="assistant-activity vstack">
+    <div v-if="agent && activeTab === 'activity'" class="agent-activity vstack">
         <ActivityListItem
-          v-for="(item, idx) in assistant.activity"
+          v-for="(item, idx) in agent.activity"
           :key="idx"
           :item="item"
-          :to="`/assistant/${assistant.id}/activity/${item.id}`"
+          :to="`/agent/${agent.id}/activity/${item.id}`"
         />
     </div>
 
@@ -106,38 +106,38 @@ import { computed, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import ToolListItem from '@/components/ToolListItem.vue';
 import Modal from '@/components/Modal.vue';
-import { assistants } from '@/data/assistants.js';
+import { agents } from '@/data/agents.js';
 import { Plus } from 'lucide-vue-next';
 import { parseInstructions } from '@/data/parseInstructions.js';
 import { tools } from '@/data/tools.js';
 import ActivityListItem from '@/components/ActivityListItem.vue';
-import AssistantPreview from '@/components/AssistantPreview.vue';
+import AgentPreview from '@/components/AgentPreview.vue';
 import InstructionsField from '@/components/InstructionsField.vue';
 
 const route = useRoute();
 const router = useRouter();
-const assistantId = computed(() => Number(route.params.id));
-const assistant = computed(() => assistants.find(a => a.id === assistantId.value));
+const agentId = computed(() => Number(route.params.id));
+const agent = computed(() => agents.find(a => a.id === agentId.value));
 const activeTab = ref(route.query.tab || 'workbench');
 
 const parsedInstructions = computed(() =>
-  assistant.value ? parseInstructions(assistant.value.instructions) : []
+  agent.value ? parseInstructions(agent.value.instructions) : []
 );
 
 const autocomplete = ref({ show: false, x: 0, y: 0, query: '', filtered: tools, caretNode: null });
 
-const trigger = ref(assistant.value ? assistant.value.trigger : 'on-demand');
+const trigger = ref(agent.value ? agent.value.trigger : 'on-demand');
 
 // Modal state for tool details
 const isToolModalOpen = ref(false);
 const selectedTool = ref(null);
 
 watch(trigger, (newVal) => {
-  if (assistant.value) assistant.value.trigger = newVal;
+  if (agent.value) agent.value.trigger = newVal;
 });
 
-watch(assistant, (newAssistant) => {
-  if (newAssistant) trigger.value = newAssistant.trigger;
+watch(agent, (newAgent) => {
+  if (newAgent) trigger.value = newAgent.trigger;
 });
 
 // Sync activeTab to URL query
@@ -247,7 +247,7 @@ function closeToolModal() {
 </script>
 
 <style scoped>
-.assistant-container {
+.agent-container {
   height: 100%;
   display: flex;
   flex-direction: column;
@@ -264,8 +264,8 @@ header {
   border-bottom: 1px solid var(--color-surface-tint);
 }
 
-.assistant-header-start,
-.assistant-header-end {
+.agent-header-start,
+.agent-header-end {
   display: flex;
   align-items: center;
   gap: var(--space-m);
@@ -302,7 +302,7 @@ nav li:hover:not(.active) {
   background-color: var(--color-surface-tint-dark);
 }
 
-.assistant-workbench {
+.agent-workbench {
   flex: 1;
 }
 
@@ -313,7 +313,7 @@ hr {
   margin: 0 calc(-1 * var(--space-m));
 }
 
-.assistant-config {
+.agent-config {
   gap: var(--space-m);
   width: 60%;
   padding: var(--space-m);
@@ -343,23 +343,23 @@ hr {
   flex-wrap: wrap;
 }
 
-.assistant-versions {
+.agent-versions {
   padding: var(--space-m);
 }
 
-.assistant-versions h4 {
+.agent-versions h4 {
   font-size: var(--font-size-s);
   color: var(--color-surface-fg-tertiary);
 }
 
-.assistant-activity {
+.agent-activity {
   margin: var(--space-m);
   border: 1px solid var(--color-surface-tint);
   border-radius: var(--radius-m);
   overflow: hidden;
 }
 
-.assistant-insights {
+.agent-insights {
   padding: var(--space-m);
 }
 </style>

--- a/src/views/Agents.vue
+++ b/src/views/Agents.vue
@@ -1,26 +1,26 @@
 <template>
-  <div class="assistants-toolbar">
+  <div class="agents-toolbar">
     <div class="toolbar-start">
-      <input type="search" placeholder="Search assistants" />
+      <input type="search" placeholder="Search agents" />
     </div>
     <div class="toolbar-end">
-      <button>New assistant</button>
+      <button>New agent</button>
     </div>
   </div>
 
-  <div class="assistant-list">
+  <div class="agent-list">
     <div
-      v-for="assistant in assistants"
-      :key="assistant.id"
-      class="assistant-item"
-      @click="goToAssistant(assistant, $event)"
+      v-for="agent in agents"
+      :key="agent.id"
+      class="agent-item"
+      @click="goToAgent(agent, $event)"
       style="user-select: none;"
     >
-      <router-link :to="`/assistant/${assistant.id}`" class="assistant-title">{{ assistant.title }}</router-link>
-      <div class="assistant-description">{{ assistant.description }}</div>
-      <div class="assistant-owner hstack">
-        <img height="24" width="24" :src="`/images/${assistant.ownerIcon}`" class="assistant-owner-icon" />
-        <span class="assistant-owner-name">{{ assistant.owner }}</span>
+      <router-link :to="`/agent/${agent.id}`" class="agent-title">{{ agent.title }}</router-link>
+      <div class="agent-description">{{ agent.description }}</div>
+      <div class="agent-owner hstack">
+        <img height="24" width="24" :src="`/images/${agent.ownerIcon}`" class="agent-owner-icon" />
+        <span class="agent-owner-name">{{ agent.owner }}</span>
       </div>
     </div>
   </div>
@@ -28,37 +28,37 @@
 
 <script setup>
 import { RouterLink, useRouter } from 'vue-router';
-import { assistants } from '@/data/assistants.js';
+import { agents } from '@/data/agents.js';
 
 const router = useRouter();
 
-function goToAssistant(assistant, event) {
+function goToAgent(agent, event) {
   // Prevent navigation if the router-link was clicked
   if (
-    event.target.closest('.assistant-title')
+    event.target.closest('.agent-title')
   ) {
     return;
   }
-  router.push(`/assistant/${assistant.id}`);
+  router.push(`/agent/${agent.id}`);
 }
 </script> 
 
 <style scoped>
-.assistants-toolbar {
+.agents-toolbar {
   display: flex;
   justify-content: space-between;
   gap: var(--space-s);
   padding: var(--space-s) var(--space-m);
 }
 
-.assistant-list {
+.agent-list {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   gap: var(--space-s);
   padding: 0 var(--space-m);
 }
 
-.assistant-item {
+.agent-item {
   display: flex;
   flex-direction: column;
   background: var(--color-surface);
@@ -68,18 +68,18 @@ function goToAssistant(assistant, event) {
   cursor: pointer;
 }
 
-.assistant-item:hover {
+.agent-item:hover {
   background-color: var(--color-surface-tint);
 }
 
-.assistant-title {
+.agent-title {
   font-size: var(--font-size-m);
   font-weight: var(--font-weight-bold);
   text-decoration: none;
   color: var(--color-surface-fg);
 }
 
-.assistant-description {
+.agent-description {
   color: var(--color-surface-fg-secondary);
   line-height: 1.5em;
   min-height: 3em; /* Always at least 2 lines tall */
@@ -90,7 +90,7 @@ function goToAssistant(assistant, event) {
   text-overflow: ellipsis;
 }
 
-.assistant-owner {
+.agent-owner {
   font-size: var(--font-size-s);
   padding-top: var(--space-xs);
   gap: var(--space-xs);
@@ -98,13 +98,13 @@ function goToAssistant(assistant, event) {
   color: var(--color-surface-fg-tertiary);
 }
 
-.assistant-owner-icon {
+.agent-owner-icon {
   height: 16px;
   width: 16px;
   border-radius: var(--radius-s);
 }
 
-.assistant-tools {
+.agent-tools {
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-xs);

--- a/src/views/Conversation.vue
+++ b/src/views/Conversation.vue
@@ -26,21 +26,21 @@
 <script setup>
 import { computed } from 'vue';
 import { useRoute } from 'vue-router';
-import { assistants } from '@/data/assistants.js';
+import { agents } from '@/data/agents.js';
 import { conversations } from '@/data/conversations.js';
 
 const route = useRoute();
-const assistantId = computed(() => Number(route.params.id));
+const agentId = computed(() => Number(route.params.id));
 const activityId = computed(() => Number(route.params.activityId));
 
-const assistant = computed(() => assistants.find(a => a.id === assistantId.value));
-const conversationItem = computed(() => assistant.value?.activity.find(a => a.id === activityId.value));
+const agent = computed(() => agents.find(a => a.id === agentId.value));
+const conversationItem = computed(() => agent.value?.activity.find(a => a.id === activityId.value));
 const conversation = computed(() => {
   const convId = conversationItem.value?.conversationId;
   return conversations.find(c => c.id === convId);
 });
 
-const backLink = computed(() => `/assistant/${assistantId.value}?tab=activity`);
+const backLink = computed(() => `/agent/${agentId.value}?tab=activity`);
 
 function formatDate(datetime) {
   const date = new Date(datetime);
@@ -76,7 +76,7 @@ header {
   background-color: var(--color-surface-tint);
   border-radius: var(--radius);
 }
-.message.assistant {
+.message.agent {
   background-color: var(--color-accent);
   color: var(--color-accent-fg);
 }


### PR DESCRIPTION
## Summary
- rename UI and code from Assistant to Agent
- adjust routing and dataset to use new names

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685478c3d8bc83258ea97c272da1f1b7