### PR TITLE
Fix overflow in activity list

### DIFF
--- a/src/components/ActivityListItem.vue
+++ b/src/components/ActivityListItem.vue
@@ -55,6 +55,8 @@ function gravatarUrl(email) {
   border-bottom: 1px solid var(--color-surface-tint);
   cursor: pointer;
   text-decoration: none;
+  width: 100%;
+  min-width: 0;
 }
 
 .activity-list-item:last-child {
@@ -95,5 +97,7 @@ function gravatarUrl(email) {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
 }
 </style> 


### PR DESCRIPTION
## Summary
- prevent ActivityListItem from stretching outside its container
- allow the summary snippet to shrink and truncate

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6854841cb4388325b8e1f39048cd6e9f