### PR TITLE
Open tool modal from instructions

### DIFF
--- a/src/components/InstructionsField.vue
+++ b/src/components/InstructionsField.vue
@@ -14,6 +14,7 @@
             v-else-if="part.type === 'tool'"
             class="highlight-tool"
             contenteditable="false"
+            @click="onToolClick(part)"
           >
             @{{ part.title }}<template v-if="part.value">:<span class="tool-value">{{ part.value }}</span></template>
           </span>
@@ -43,7 +44,7 @@ const props = defineProps({
   autocomplete: Object,
   tools: Array
 });
-const emit = defineEmits(['update:modelValue', 'input', 'keydown', 'select-tool', 'autocomplete-change']);
+const emit = defineEmits(['update:modelValue', 'input', 'keydown', 'select-tool', 'autocomplete-change', 'tool-click']);
 
 const fieldRef = ref(null);
 
@@ -58,6 +59,10 @@ function onTextFieldKeydown(e) {
 
 function selectTool(tool) {
   emit('select-tool', tool);
+}
+
+function onToolClick(part) {
+  emit('tool-click', part);
 }
 </script>
 

--- a/src/views/Agent.vue
+++ b/src/views/Agent.vue
@@ -35,6 +35,7 @@
             @input="onTextFieldInput"
             @keydown="onTextFieldKeydown"
             @select-tool="selectTool"
+            @tool-click="onInstructionToolClick"
           />
         </div>
 
@@ -200,6 +201,7 @@ function selectTool(tool) {
   span.className = 'highlight-tool';
   span.setAttribute('contenteditable', 'false');
   span.textContent = `@${tool.title}`;
+  span.addEventListener('click', () => onInstructionToolClick({ title: tool.title }));
   const afterNode = document.createTextNode(after);
   parent.replaceChild(afterNode, node);
   parent.insertBefore(span, afterNode);
@@ -233,6 +235,13 @@ function onTextFieldKeydown(e) {
     } else if (e.key === 'Escape') {
       autocomplete.value.show = false;
     }
+  }
+}
+
+function onInstructionToolClick(part) {
+  const tool = tools.find(t => t.title === part.title);
+  if (tool) {
+    openToolModal(tool);
   }
 }
 


### PR DESCRIPTION
## Summary
- emit `tool-click` from `InstructionsField`
- open the modal when clicking a tool reference in instructions
- attach click handler to new spans inserted via autocomplete

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68548b19e9b48325aa39ddf16d0198d3